### PR TITLE
Parsing date from array (extension)

### DIFF
--- a/BuildaUtils.xcodeproj/project.pbxproj
+++ b/BuildaUtils.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		3ACBADD31B5A904C00204457 /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A81BB6A1B5A7D9B004732CD /* Script.swift */; };
 		3ACBADD41B5A904C00204457 /* Server.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5C298A1B5A8AA80037C486 /* Server.swift */; };
 		3ACBADD51B5A904C00204457 /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A81BB6B1B5A7D9B004732CD /* TimeUtils.swift */; };
+		70E46B611B60D8A400B5D3AD /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E46B601B60D8A400B5D3AD /* ExtensionsTests.swift */; };
+		70E46B631B60DE0B00B5D3AD /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E46B621B60DE0B00B5D3AD /* TestUtils.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +62,8 @@
 		3ACBADC51B5A904700204457 /* BuildaUtilsiOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BuildaUtilsiOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3ACBADC71B5A904700204457 /* BuildaUtilsiOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BuildaUtilsiOS.h; sourceTree = "<group>"; };
 		3ACBADC91B5A904700204457 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		70E46B601B60D8A400B5D3AD /* ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
+		70E46B621B60DE0B00B5D3AD /* TestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,6 +97,8 @@
 			children = (
 				3A5C29911B5A8ABD0037C486 /* ScriptTests.swift */,
 				3A5C297E1B5A88E70037C486 /* Info.plist */,
+				70E46B601B60D8A400B5D3AD /* ExtensionsTests.swift */,
+				70E46B621B60DE0B00B5D3AD /* TestUtils.swift */,
 			);
 			path = BuildaUtilsTests;
 			sourceTree = "<group>";
@@ -290,6 +296,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A5C29921B5A8ABD0037C486 /* ScriptTests.swift in Sources */,
+				70E46B631B60DE0B00B5D3AD /* TestUtils.swift in Sources */,
+				70E46B611B60D8A400B5D3AD /* ExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -559,6 +567,7 @@
 				3ACBADCB1B5A904700204457 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/BuildaUtils/Extensions.swift
+++ b/BuildaUtils/Extensions.swift
@@ -36,3 +36,26 @@ public extension String {
     }
 }
 
+public enum DateParsing: ErrorType {
+    case WrongNumberOfElements(Int)
+}
+
+public extension Array where Element: IntegerType {
+    
+    public func dateString() throws -> String {
+        let elementsCount = self.count
+        let formatter = NSNumberFormatter()
+        formatter.minimumIntegerDigits = 2
+        let formattedSelf = self.flatMap { formatter.stringFromNumber($0 as! NSNumber) }
+        
+        switch elementsCount {
+        case 6:
+            return "\(formattedSelf[0])-\(formattedSelf[1])-\(formattedSelf[2])T\(formattedSelf[3]):\(formattedSelf[4]):\(formattedSelf[5])"
+        case 7:
+            return "\(formattedSelf[0])-\(formattedSelf[1])-\(formattedSelf[2])T\(formattedSelf[3]):\(formattedSelf[4]):\(formattedSelf[5]).\(formattedSelf[6])Z"
+        default:
+            throw DateParsing.WrongNumberOfElements(elementsCount)
+        }
+    }
+    
+}

--- a/BuildaUtilsTests/ExtensionsTests.swift
+++ b/BuildaUtilsTests/ExtensionsTests.swift
@@ -1,0 +1,35 @@
+//
+//  ExtensionsTests.swift
+//  BuildaUtils
+//
+//  Created by Mateusz Zając on 23/07/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import XCTest
+import BuildaUtils
+
+class ExtensionsTests: XCTestCase {
+
+    // MARK: Array extension tests
+    
+    let xcode6 = [2015, 7, 23, 6, 47, 28]
+    let xcode7 = [2015, 7, 23, 6, 47, 28, 845]
+    
+    func testAcceptingArrays() {
+        XCTempAssertNoThrowError() {
+            try self.xcode7.dateString()
+            try self.xcode6.dateString()
+        }
+        
+        XCTempAssertThrowsSpecificError(DateParsing.WrongNumberOfElements(4)) {
+            try [1, 2, 3, 4].dateString()
+        }
+    }
+    
+    func testDateParsing() {
+        XCTAssertEqual(try! xcode6.dateString(), "2015-07-23T06:47:28")
+        XCTAssertEqual(try! xcode7.dateString(), "2015-07-23T06:47:28.845Z")
+    }
+    
+}

--- a/BuildaUtilsTests/TestUtils.swift
+++ b/BuildaUtilsTests/TestUtils.swift
@@ -1,0 +1,93 @@
+//
+//  TestUtils.swift
+//  BuildaUtils
+//
+//  Created by Mateusz Zając on 23/07/15.
+//  Copyright © 2015 Honza Dvorsky. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+// MARK: Exception assertions
+// Based on: https://forums.developer.apple.com/thread/5824
+extension XCTestCase {
+    /**
+    Replacement method for XCTAssertThrowsError which isn't currently supported.
+    
+    - parameter message: Message which should be displayed
+    - parameter file:    File in which assertion happened
+    - parameter line:    Line in which assertion happened
+    - parameter block:   Block of code against which assertion should be matched
+    */
+    func XCTempAssertThrowsError(message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ block: () throws -> ()) {
+        do {
+            try block()
+            
+            let msg = (message == "") ? "Tested block did not throw error as expected." : message
+            XCTFail(msg, file: file, line: line)
+        } catch {}
+    }
+    
+    /**
+    Replacement method for XCTAssertThrowsSpecificError which isn't currently supported.
+    
+    - parameter kind:    ErrorType which is expected to be thrown from block
+    - parameter message: Message which should be displayed
+    - parameter file:    File in which assertion happened
+    - parameter line:    Line in which assertion happened
+    - parameter block:   Block of code against which assertion should be matched
+    */
+    func XCTempAssertThrowsSpecificError(kind: ErrorType, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ block: () throws -> ()) {
+        do {
+            try block()
+            
+            let msg = (message == "") ? "Tested block did not throw expected \(kind) error." : message
+            XCTFail(msg, file: file, line: line)
+        } catch let error as NSError {
+            let expected = kind as NSError
+            if ((error.domain != expected.domain) || (error.code != expected.code)) {
+                let msg = (message == "") ? "Tested block threw \(error), not expected \(kind) error." : message
+                XCTFail(msg, file: file, line: line)
+            }
+        }
+    }
+    
+    /**
+    Replacement method for XCTAssertNoThrowsError which isn't currently supported.
+    
+    - parameter message: Message which should be displayed
+    - parameter file:    File in which assertion happened
+    - parameter line:    Line in which assertion happened
+    - parameter block:   Block of code against which assertion should be matched
+    */
+    func XCTempAssertNoThrowError(message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ block: () throws -> ()) {
+        do {
+            try block()
+        } catch {
+            let msg = (message == "") ? "Tested block threw unexpected error." : message
+            XCTFail(msg, file: file, line: line)
+        }
+    }
+    
+    /**
+    Replacement method for XCTAssertNoThrowsSpecificError which isn't currently supported.
+    
+    - parameter kind:    ErrorType which isn't expected to be thrown from block
+    - parameter message: Message which should be displayed
+    - parameter file:    File in which assertion happened
+    - parameter line:    Line in which assertion happened
+    - parameter block:   Block of code against which assertion should be matched
+    */
+    func XCTempAssertNoThrowSpecificError(kind: ErrorType, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__, _ block: () throws -> ()) {
+        do {
+            try block()
+        } catch let error as NSError {
+            let unwanted = kind as NSError
+            if ((error.domain == unwanted.domain) && (error.code == unwanted.code)) {
+                let msg = (message == "") ? "Tested block threw unexpected \(kind) error." : message
+                XCTFail(msg, file: file, line: line)
+            }
+        }
+    }
+}


### PR DESCRIPTION
As we've discussed in `XcodeServerSDK` repo...

Here's the code for this with test coverage. I've decided to write `extension` on `Array` which converts it to date-like `String` we know from other `response`s 😉

Maybe it's not the best approach on this and it's error prone, but I think there's no point in writing something more general as it's a specific case and we, probably, won't use it in more places.
Anyway I'm open for some suggestions...

---

@czechboy0 **you probably didn't expect me here...**
![](http://media2.giphy.com/media/12h4O67FjZagg0/giphy.gif)
