### PR TITLE
Path error workaround

### DIFF
--- a/BuildaUtils/Script.swift
+++ b/BuildaUtils/Script.swift
@@ -60,7 +60,9 @@ public class Script {
     private class func runInTemporaryScript(script: String, block: (scriptPath: String, error: NSError?) -> ()) {
         
         let uuid = NSUUID().UUIDString
-        let tempPath = NSTemporaryDirectory().stringByAppendingPathComponent(uuid)
+        // Bug? https://forums.developer.apple.com/thread/13580
+        let tempDirectory = NSTemporaryDirectory() as NSString
+        let tempPath = tempDirectory.stringByAppendingPathComponent(uuid)
         
         do {
             //write the script to file

--- a/BuildaUtils/Script.swift
+++ b/BuildaUtils/Script.swift
@@ -60,7 +60,8 @@ public class Script {
     private class func runInTemporaryScript(script: String, block: (scriptPath: String, error: NSError?) -> ()) {
         
         let uuid = NSUUID().UUIDString
-        let tempPath = NSTemporaryDirectory().stringByAppendingPathComponent(uuid)
+        // Bug? https://forums.developer.apple.com/thread/13580
+        let tempPath = (NSTemporaryDirectory() as NSString).stringByAppendingPathComponent(uuid)
         
         do {
             //write the script to file


### PR DESCRIPTION
Looks like theres is a _bug_ in Xcode 7b5... `BuildaUtils` won't build because of `stringByAppendingPathComponent` - claiming that this method is available only for `NSString` but we're trying to call it on `String`... 😐

Of course, other ppl are facing the same issue (https://forums.developer.apple.com/thread/13580), so for now we'll have to do what I've done in this PR.
