### PR TITLE
Add support for splitting log files

### DIFF
--- a/BuildaUtils.xcodeproj/project.pbxproj
+++ b/BuildaUtils.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		3A81BB6D1B5A7D9B004732CD /* Script.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A81BB6A1B5A7D9B004732CD /* Script.swift */; };
 		3A81BB6E1B5A7D9B004732CD /* TimeUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A81BB6B1B5A7D9B004732CD /* TimeUtils.swift */; };
 		3AC722031BB5F8090005FF4B /* HTTPUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC722021BB5F8090005FF4B /* HTTPUtilsTests.swift */; };
+		5DCDD67F1C4A69320027717F /* FileLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DCDD67E1C4A69320027717F /* FileLoggerTests.swift */; };
 		70E46B611B60D8A400B5D3AD /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E46B601B60D8A400B5D3AD /* ExtensionsTests.swift */; };
 		70E46B631B60DE0B00B5D3AD /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70E46B621B60DE0B00B5D3AD /* TestUtils.swift */; };
 /* End PBXBuildFile section */
@@ -57,6 +58,7 @@
 		3A81BB6A1B5A7D9B004732CD /* Script.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Script.swift; sourceTree = "<group>"; };
 		3A81BB6B1B5A7D9B004732CD /* TimeUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeUtils.swift; sourceTree = "<group>"; };
 		3AC722021BB5F8090005FF4B /* HTTPUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPUtilsTests.swift; sourceTree = "<group>"; };
+		5DCDD67E1C4A69320027717F /* FileLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileLoggerTests.swift; sourceTree = "<group>"; };
 		70E46B601B60D8A400B5D3AD /* ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
 		70E46B621B60DE0B00B5D3AD /* TestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -89,6 +91,7 @@
 				3A5C29911B5A8ABD0037C486 /* ScriptTests.swift */,
 				70E46B621B60DE0B00B5D3AD /* TestUtils.swift */,
 				3A0FF5AB1BBFFF9100FB8051 /* AvailabilityTests.swift */,
+				5DCDD67E1C4A69320027717F /* FileLoggerTests.swift */,
 			);
 			path = BuildaUtilsTests;
 			sourceTree = "<group>";
@@ -245,6 +248,7 @@
 				70E46B611B60D8A400B5D3AD /* ExtensionsTests.swift in Sources */,
 				3A0FF5AC1BBFFF9100FB8051 /* AvailabilityTests.swift in Sources */,
 				3AC722031BB5F8090005FF4B /* HTTPUtilsTests.swift in Sources */,
+				5DCDD67F1C4A69320027717F /* FileLoggerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BuildaUtilsTests/FileLoggerTests.swift
+++ b/BuildaUtilsTests/FileLoggerTests.swift
@@ -1,0 +1,82 @@
+//
+//  FileLoggerTests.swift
+//  BuildaUtils
+//
+//  Created by Joel Ekström on 2016-01-16.
+//  Copyright © 2016 Honza Dvorsky. All rights reserved.
+//
+
+import XCTest
+@testable import BuildaUtils
+
+class FileLoggerTests: XCTestCase {
+
+    let fileSizeCap = 1000 as UInt64
+    var logger: FileLogger!
+    var logFileURL = NSURL()
+    
+    override func setUp() {
+        super.setUp()
+
+        let directoryPath = createUniqueTemporaryDirectory()!
+        self.logFileURL = directoryPath.URLByAppendingPathComponent("test.log")
+        self.logger = FileLogger(fileURL: self.logFileURL)
+        self.logger.fileSizeCap = fileSizeCap
+    }
+
+    func testFileSizeCounter() {
+        let message = "Testing to write something to the log!"
+        let message2 = "Writing something more"
+
+        let messageSize = "\(message)\n".dataUsingEncoding(NSUTF8StringEncoding)!.length
+        let message2Size = "\(message2)\n".dataUsingEncoding(NSUTF8StringEncoding)!.length
+        let totalSize = messageSize + message2Size
+
+        self.logger.log(message)
+        XCTAssertEqual(self.logger.fileSize, UInt64(messageSize))
+
+        self.logger.log(message2)
+        XCTAssertEqual(self.logger.fileSize, UInt64(totalSize))
+
+        // Create new logger to test that reading initial file size works
+        self.logger.stream.close()
+        self.logger = FileLogger(fileURL: self.logFileURL)
+        XCTAssertEqual(self.logger.fileSize, UInt64(totalSize))
+    }
+
+    func testFileArchiving() {
+        let message = "Testing to write something to the log!"
+        let messageSize = UInt64("\(message)\n".dataUsingEncoding(NSUTF8StringEncoding)!.length)
+
+        var sizeCounter = 0 as UInt64
+        while true {
+            if self.logger.fileSize! + messageSize < fileSizeCap {
+                self.logger.log(message)
+                sizeCounter = sizeCounter + messageSize
+            } else {
+                break;
+            }
+        }
+
+        XCTAssertEqual(self.logger.fileSize, sizeCounter)
+        self.logger.log(message)
+        XCTAssertEqual(self.logger.fileSize, messageSize)
+    }
+
+    func createUniqueTemporaryDirectory() -> NSURL? {
+        let template = NSURL(fileURLWithPath: NSTemporaryDirectory()).URLByAppendingPathComponent("buildautils-test-XXXXXX")
+
+        // Fill buffer with a C string representing the local file system path.
+        var buffer = [Int8](count: Int(PATH_MAX), repeatedValue: 0)
+        template.getFileSystemRepresentation(&buffer, maxLength: buffer.count)
+
+        // Create unique file name (and open file):
+        let fd = mkdtemp(&buffer)
+        if fd != nil {
+            return NSURL(fileURLWithFileSystemRepresentation: buffer, isDirectory: false, relativeToURL: nil)
+        } else {
+            print("Error: " + String(strerror(errno)))
+            return nil
+        }
+    }
+}

--- a/BuildaUtilsTests/FileLoggerTests.swift
+++ b/BuildaUtilsTests/FileLoggerTests.swift
@@ -54,7 +54,7 @@ class FileLoggerTests: XCTestCase {
                 self.logger.log(message)
                 sizeCounter = sizeCounter + messageSize
             } else {
-                break;
+                break
             }
         }
 

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -16,26 +16,96 @@ public protocol Logger {
 
 public class FileLogger: Logger {
     
-    let filePath: NSURL
-    let stream: NSOutputStream
-    
-    public init(filePath: NSURL) {
-        self.filePath = filePath
-        self.stream = NSOutputStream(URL: filePath, append: true)!
+    let fileURL: NSURL
+
+    // Split log files at this byte size. If nil, never split files (default: 1MB)
+    var fileSizeCap: UInt64? = 1024 * 1024
+
+    // If false, delete old log files when splitting on fileSizeCap
+    var shouldKeepArchivedLogs = true
+
+    internal var stream: NSOutputStream
+    internal var fileSize: UInt64? {
+        do {
+            let fileAttributes = try NSFileManager.defaultManager().attributesOfItemAtPath(fileURL.path!) as NSDictionary
+            return fileAttributes.fileSize()
+        } catch {
+            return nil
+        }
+    }
+
+    lazy private var dateFormatter: NSDateFormatter = {
+        let enUSPosixLocale = NSLocale(localeIdentifier: "en_US_POSIX")
+        let formatter = NSDateFormatter()
+        formatter.locale = enUSPosixLocale
+        formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-SS"
+        return formatter
+    }()
+
+    public init(fileURL: NSURL) {
+        assert(fileURL.fileURL, "URL to log file has to be a File URL")
+        self.fileURL = fileURL
+
+        if !NSFileManager.defaultManager().fileExistsAtPath(fileURL.absoluteString) {
+            NSFileManager.defaultManager().createFileAtPath(fileURL.absoluteString, contents: nil, attributes: nil)
+        }
+
+        self.stream = NSOutputStream(URL: fileURL, append: true)!;
         self.stream.open()
     }
-    
+
     deinit {
         self.stream.close()
     }
-    
+
     public func description() -> String {
-        return "File logger into file at path \(self.filePath)"
+        return "File logger into file at path \(self.fileURL)"
     }
     
     public func log(message: String) {
         let data: NSData = "\(message)\n".dataUsingEncoding(NSUTF8StringEncoding)!
+
+        if shouldArchiveFileBeforeLogging(data) {
+            archiveLogFile()
+        }
+
         self.stream.write(UnsafePointer<UInt8>(data.bytes), maxLength: data.length)
+    }
+
+    internal func shouldArchiveFileBeforeLogging(data: NSData) -> Bool {
+        guard let cap = self.fileSizeCap else {
+            return false
+        }
+
+        guard let currentSize = self.fileSize else {
+            return false
+        }
+
+        let sizeAfterWrite = currentSize + UInt64(data.length)
+        return sizeAfterWrite > cap
+    }
+
+
+    private func archiveLogFile() {
+        self.stream.close()
+
+        let components = NSURLComponents(URL: fileURL, resolvingAgainstBaseURL: false)
+        let dateString = dateFormatter.stringFromDate(NSDate())
+        components!.path = components!.path?.stringByAppendingString(dateString)
+
+        do {
+            if self.shouldKeepArchivedLogs {
+                try NSFileManager.defaultManager().moveItemAtURL(fileURL.filePathURL!, toURL: components!.URL!)
+            } else {
+                try NSFileManager.defaultManager().removeItemAtURL(fileURL.filePathURL!)
+            }
+
+            NSFileManager.defaultManager().createFileAtPath(fileURL.absoluteString, contents: nil, attributes: nil)
+            self.stream = NSOutputStream(URL: fileURL, append: true)!;
+            self.stream.open()
+        } catch let error {
+            print(error)
+        }
     }
 }
 

--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -50,7 +50,7 @@ public class FileLogger: Logger {
             NSFileManager.defaultManager().createFileAtPath(fileURL.absoluteString, contents: nil, attributes: nil)
         }
 
-        self.stream = NSOutputStream(URL: fileURL, append: true)!;
+        self.stream = NSOutputStream(URL: fileURL, append: true)!
         self.stream.open()
     }
 
@@ -101,7 +101,7 @@ public class FileLogger: Logger {
             }
 
             NSFileManager.defaultManager().createFileAtPath(fileURL.absoluteString, contents: nil, attributes: nil)
-            self.stream = NSOutputStream(URL: fileURL, append: true)!;
+            self.stream = NSOutputStream(URL: fileURL, append: true)!
             self.stream.open()
         } catch let error {
             print(error)


### PR DESCRIPTION
By default, FileLogger will now create new log files when they
are more than 1MB. This can be customized with the 'fileSizeCap'-
property.

Also, you can set 'shouldKeepArchivedLogs' to 'false' to just
delete old logs when reaching a certain size. This has the drawback
of losing all current logs and starting fresh when reaching the cap,
instead of just deleting entries in the beginning of the file.

A good addition to this PR would be keeping a fix number of archived files and deleting older ones when new ones are created, but it will require additional state logic.
