### PR TITLE
Make file cap/log persistance options public

### DIFF
--- a/Source/Logging.swift
+++ b/Source/Logging.swift
@@ -19,10 +19,10 @@ public class FileLogger: Logger {
     let fileURL: NSURL
 
     // Split log files at this byte size. If nil, never split files (default: 1MB)
-    var fileSizeCap: UInt64? = 1024 * 1024
+    public var fileSizeCap: UInt64? = 1024 * 1024
 
     // If false, delete old log files when splitting on fileSizeCap
-    var shouldKeepArchivedLogs = true
+    public var shouldKeepArchivedLogs = true
 
     internal var stream: NSOutputStream
     internal var fileSize: UInt64? {


### PR DESCRIPTION
Pardon my Swift-awkwardness - I just realized I forgot this when trying to integrate them into Buildasaur 😰 I suppose this requires another release...
