### PR TITLE
Initial setup errors

### DIFF
--- a/BuildaUtils.podspec
+++ b/BuildaUtils.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
                    Both Buildasaur and XcodeServerSDK need similar utilities. This is where I keep them.
                    DESC
 
-  s.homepage     = "https://github.com/czechboy0/BuildaUtils"
+  s.homepage     = "https://github.com/buildasaurs/BuildaUtils"
   s.license      = { :type => "MIT", :file => "LICENSE.md" }
 
   s.author             = { "Honza Dvorsky" => "http://honzadvorsky.com" }
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
 
-  s.source       = { :git => "https://github.com/czechboy0/BuildaUtils.git", :tag => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/buildasaurs/BuildaUtils.git", :tag => "v#{s.version}" }
   s.source_files  = "Source/*.{swift}"
 
   # load the dependencies from the podfile for target ekgclient

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@
 use_frameworks!
 
 target 'BuildaUtils' do
-	pod 'SwiftSafe', '~> 0.1'
+	pod 'SwiftSafe'
 end
 
 target 'BuildaUtilsTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,12 @@
 PODS:
-  - SwiftSafe (0.1)
+  - SwiftSafe (2.0.0)
 
 DEPENDENCIES:
-  - SwiftSafe (~> 0.1)
+  - SwiftSafe
 
 SPEC CHECKSUMS:
-  SwiftSafe: 77ffd12b02678790bec1ef56a2d14ec5036f1fd6
+  SwiftSafe: b64ef3119a0b906e9ca6f67cd1705f351c9a8f9c
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: 4740cd66c3a57dedbdf642fe9f7e3706ca41698e
+
+COCOAPODS: 1.1.0.rc.3


### PR DESCRIPTION
In this pull request was fixed the following errrors:
-  When you tried  to run `fastlane prebuild` it fails, mainly because the version of **SwiftSafe** pointing there not exist anymore (`v.0.1`). 
- Was updated the version of SwiftSafe accordingly in the Podfile.
- To be able to run `fastlane prebuild` after the two following steps was necessary to delete the `Podfile.lock` and replace with the new one with all the dependencies updated or run `pod update` to install the new dependency.

Before run the validation of the `BuildaUtils.podspec` using `pod spec lint` is necessary to migrate the project to Swift 3.0, mainly because when the lint of Cocoapods runs it find that the **SwifSafe** project is written completely in Swift 3 and return errors in the files regarding **SwifSafe**.
